### PR TITLE
Replace Deprecated matchclass command

### DIFF
--- a/20LinesOrLess/access_control_by_ip.txt
+++ b/20LinesOrLess/access_control_by_ip.txt
@@ -1,5 +1,8 @@
+
+# iRule to restrict access to a datagroup named "trusted_users". This datagroup can be created in the BIG-IP WebUI
+
 when CLIENT_ACCEPTED  {
-  if { [matchclass [IP::client_addr] equals $::trustedAddresses] }{
+  if { [class match [IP::client_addr] equals "trusted_users" ] }{
     #Uncomment the line below to turn on logging.
     #log local0.  "Valid client IP: [IP::client_addr] - forwarding traffic"
     forward


### PR DESCRIPTION
Matchclass was deprecated some time ago, and the documentation suggests this iRule would not function in V11+