### PR TITLE
Update cookie_encryption_gateway.txt

### DIFF
--- a/20LinesOrLess/cookie_encryption_gateway.txt
+++ b/20LinesOrLess/cookie_encryption_gateway.txt
@@ -1,9 +1,8 @@
+# An iRule to encrypt cookies. Note that this may also be achievable through "Encrypt Cookies" option within the HTTP Profile, which also stores the passphrase in SecureVault. There may, however, be situations where the iRule offers more flexibility
+# We recommend using AES::key or a reliable password generator to generate an appropriate passphrase
+
 when RULE_INIT {
-  # Exposed passphrase, but this key can be synchronized to the peer LTM
   set static::passphrase "secret"
-  # Private passphrase, but it isn't synchronized.  On LTM failover to
-  # its peer, applications relying on the encrypted cookies will break.
-  # set static::passphrase [AES::key]
 }
 when HTTP_REQUEST {
   foreach { cookieName } [HTTP::cookie names] {


### PR DESCRIPTION
Removed the code which generated an AES key at runtime; this was not CMP compatible, while using the static::namespace to allow CMP to operate.  Added description